### PR TITLE
Configures Critical CSS defaults

### DIFF
--- a/config/critical_css.settings.yml
+++ b/config/critical_css.settings.yml
@@ -1,0 +1,5 @@
+enabled: true
+enabled_for_logged_in_users: false
+preload_non_critical_css: false
+dir_path: /critical-css/css
+excluded_ids: ''


### PR DESCRIPTION
Adds configuration that enables the Critical CSS module and tells it where the css files are at in the saplings_child theme.